### PR TITLE
Add a mechanism to reset the default task spawn order

### DIFF
--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -333,6 +333,9 @@ int qthread_spawn(qthread_f             f,
 /* This is a function to move a thread from one shepherd to another. */
 int qthread_migrate_to(const qthread_shepherd_id_t shepherd);
 
+/* Resets the default shepherd spawn order for tasks that use NO_SHEPHERD */
+void qthread_reset_target_shep(void);
+
 /* This function sets the debug level if debugging has been enabled */
 int qthread_debuglevel(int);
 

--- a/src/qthread.c
+++ b/src/qthread.c
@@ -3000,6 +3000,19 @@ int API_FUNC qthread_migrate_to(const qthread_shepherd_id_t shepherd)
     }
 }                      /*}}} */
 
+void API_FUNC qthread_reset_target_shep(void) {
+    assert(qthread_library_initialized);
+    qthread_t *me = qthread_internal_self();
+
+    if (me) {
+        assert(me->rdata);
+        me->rdata->shepherd_ptr->sched_shepherd = 0;
+    } else {
+        qlib->sched_shepherd = 0;
+        MACHINE_FENCE;
+    }
+}
+
 
 /* These are just accessor functions */
 unsigned int API_FUNC qthread_id(void)


### PR DESCRIPTION
Add `qthread_reset_target_shep()`, which resets the shepherd that tasks created with `NO_SHEPHERD` get spawned to. This is useful in Chapel for cases where we want to use the default spawn location, but get good NUMA affinity between data parallel loops sepreated by some other task spawn.

Just using the `qthread_fork_to` API would disable future stealing, so this is a mechanism  to get tasks in consecutive data parallel loops to spawn to the same shepherds without preventing stealing.

This was originally done in chapel-lang/chapel#12868, which includes some perf results. At the time I expected we'd update our shim to use `qthread_fork_to`, but had not considered the work-stealing implications at the time.