### PR TITLE
Typo in Clang CI Build Matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,14 +56,12 @@ jobs:
             gcc_version: 12
           - clang_version: 16
             gcc_version: 13
-          - clang_version: 17
-            gcc_version: 13
     env:
       CC: clang-${{ matrix.clang_version }}
       CXX: clang++${{ matrix.clang_version }}
     steps:
     - uses: actions/checkout@v3
-    - if: ${{ matrix.clang_version == '16' || matrix.clang_version == 17 }}
+    - if: ${{ matrix.clang_version == '16' }}
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && break || sleep 1
         sudo apt-add-repository 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ matrix.clang_version }} main' && break || sleep 1


### PR DESCRIPTION
This fixes a minor bug in https://github.com/sandialabs/qthreads/pull/171 where there was still a lingering clang-17 build getting generated by the main clang-on-linux matrix.