### PR TITLE
Proposed clang-format Config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,31 @@
+BasedOnStyle: LLVM
+ArrayInitializerAlignmentStyle: AIAS_Right
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros: ['Q_UNUSED', 'STACKLEFT_NOINLINE']
+BinPackArguments: false
+BinPackParameters: false
+BreakArrays: false
+BreakBeforeConceptDeclarationsStyle: Always
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+EmptyLineBeforeAccessModifier: Never
+IncludeIsMainRegex: ''
+IndentCaseLabels: true
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: true
+QualifierAlignment: Right
+QualifierOrder: ['inline', 'static', 'friend', 'constexpr', 'type', 'const', 'volatile' , 'restrict' ]
+RemoveSemicolon: true
+SeparateDefinitionBlocks: Always
+SortIncludes: CaseInsensitive
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeRangeBasedForLoopColon: false
+SpacesInContainerLiterals: false
+


### PR DESCRIPTION
I'd like to start using clang-format to manage formatting. As far as I can tell, the formatting isn't especially consistent across the codebase right now. Here's an initial config based on my own preferences that we can use as a starting point. Feel free to suggest any changes.

I'll leave this open for a while to give time for any comments. Once we've settled on a format spec to use, I'll set things up to exclude any vendored files, apply the format to the whole codebase whenever there aren't open pull requests, then set up a CI build to check that the formatting has been correctly applied to each pull request.