### PR TITLE
Fix Syncvar and FEB Lock/Unlock In Different Threads

### DIFF
--- a/src/feb.c
+++ b/src/feb.c
@@ -61,6 +61,7 @@ typedef enum bt {
 } blocker_type;
 typedef struct {
     pthread_mutex_t lock;
+    pthread_cond_t condition;
     void           *a;
     void           *b;
     blocker_type    type;
@@ -230,7 +231,9 @@ static aligned_t qthread_feb_blocker_thread(void *arg)
             a->retval = qthread_empty(a->a);
             break;
     }
-    pthread_mutex_unlock(&(a->lock));
+    pthread_mutex_lock(&a->lock);
+    pthread_cond_signal(&a->condition);
+    pthread_mutex_unlock(&a->lock);
     return 0;
 }                                      /*}}} */
 
@@ -238,12 +241,13 @@ static int qthread_feb_blocker_func(void        *dest,
                                     void        *src,
                                     blocker_type t)
 {   /*{{{*/
-    qthread_feb_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_feb_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
 
-    pthread_mutex_lock(&args.lock);
     qthread_fork(qthread_feb_blocker_thread, &args, NULL);
     pthread_mutex_lock(&args.lock);
+    pthread_cond_wait(&args.condition, &args.lock);
     pthread_mutex_unlock(&args.lock);
+    pthread_cond_destroy(&args.condition);
     pthread_mutex_destroy(&args.lock);
     return args.retval;
 } /*}}}*/

--- a/src/feb.c
+++ b/src/feb.c
@@ -62,6 +62,7 @@ typedef enum bt {
 typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t condition;
+    uint32_t completed;
     void           *a;
     void           *b;
     blocker_type    type;
@@ -232,6 +233,7 @@ static aligned_t qthread_feb_blocker_thread(void *arg)
             break;
     }
     pthread_mutex_lock(&a->lock);
+    a->completed = 1;
     pthread_cond_signal(&a->condition);
     pthread_mutex_unlock(&a->lock);
     return 0;
@@ -241,11 +243,11 @@ static int qthread_feb_blocker_func(void        *dest,
                                     void        *src,
                                     blocker_type t)
 {   /*{{{*/
-    qthread_feb_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_feb_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0u, dest, src, t, QTHREAD_SUCCESS };
 
-    qthread_fork(qthread_feb_blocker_thread, &args, NULL);
     pthread_mutex_lock(&args.lock);
-    pthread_cond_wait(&args.condition, &args.lock);
+    qthread_fork(qthread_feb_blocker_thread, &args, NULL);
+    while(!args.completed) pthread_cond_wait(&args.condition, &args.lock);
     pthread_mutex_unlock(&args.lock);
     pthread_cond_destroy(&args.condition);
     pthread_mutex_destroy(&args.lock);

--- a/src/syncvar.c
+++ b/src/syncvar.c
@@ -64,6 +64,7 @@ typedef enum bt {
 } blocker_type;
 typedef struct {
     pthread_mutex_t lock;
+    pthread_cond_t condition;
     void           *a;
     void           *b;
     blocker_type    type;
@@ -309,7 +310,9 @@ static aligned_t qthread_syncvar_blocker_thread(void *arg)
         case EMPTY: a->retval      = qthread_syncvar_empty(a->a); break;
         case INCR: a->retval       = qthread_syncvar_incrF(a->a, *(int64_t *)a->b); break;
     }
-    pthread_mutex_unlock(&(a->lock));
+    pthread_mutex_lock(&a->lock);
+    pthread_cond_signal(&a->condition);
+    pthread_mutex_unlock(&a->lock);
     return 0;
 }                                      /*}}} */
 
@@ -317,7 +320,7 @@ static int qthread_syncvar_nonblocker_func(void        *dest,
                                         void        *src,
                                         blocker_type t)
 {   /*{{{*/
-    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
 
     qthread_fork(qthread_syncvar_nonblocker_thread, &args, NULL);
     return args.retval;
@@ -327,12 +330,13 @@ static int qthread_syncvar_blocker_func(void        *dest,
                                         void        *src,
                                         blocker_type t)
 {   /*{{{*/
-    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
 
     pthread_mutex_lock(&args.lock);
     qthread_fork(qthread_syncvar_blocker_thread, &args, NULL);
-    pthread_mutex_lock(&args.lock);
+    pthread_cond_wait(&args.condition, &args.lock);
     pthread_mutex_unlock(&args.lock);
+    pthread_cond_destroy(&args.condition);
     pthread_mutex_destroy(&args.lock);
     return args.retval;
 } /*}}}*/

--- a/src/syncvar.c
+++ b/src/syncvar.c
@@ -65,6 +65,7 @@ typedef enum bt {
 typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t condition;
+    uint32_t completed;
     void           *a;
     void           *b;
     blocker_type    type;
@@ -311,6 +312,7 @@ static aligned_t qthread_syncvar_blocker_thread(void *arg)
         case INCR: a->retval       = qthread_syncvar_incrF(a->a, *(int64_t *)a->b); break;
     }
     pthread_mutex_lock(&a->lock);
+    a->completed = 1u;
     pthread_cond_signal(&a->condition);
     pthread_mutex_unlock(&a->lock);
     return 0;
@@ -320,7 +322,7 @@ static int qthread_syncvar_nonblocker_func(void        *dest,
                                         void        *src,
                                         blocker_type t)
 {   /*{{{*/
-    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0u, dest, src, t, QTHREAD_SUCCESS };
 
     qthread_fork(qthread_syncvar_nonblocker_thread, &args, NULL);
     return args.retval;
@@ -330,11 +332,11 @@ static int qthread_syncvar_blocker_func(void        *dest,
                                         void        *src,
                                         blocker_type t)
 {   /*{{{*/
-    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, dest, src, t, QTHREAD_SUCCESS };
+    qthread_syncvar_blocker_t args = { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0u, dest, src, t, QTHREAD_SUCCESS };
 
     pthread_mutex_lock(&args.lock);
     qthread_fork(qthread_syncvar_blocker_thread, &args, NULL);
-    pthread_cond_wait(&args.condition, &args.lock);
+    while (!args.completed) pthread_cond_wait(&args.condition, &args.lock);
     pthread_mutex_unlock(&args.lock);
     pthread_cond_destroy(&args.condition);
     pthread_mutex_destroy(&args.lock);


### PR DESCRIPTION
Fixes #202.

As best I can tell, this function is only ever called in one place and the lock is managed by the caller there, so no unlock is needed. It's probably a leftover typo from some previous refactoring.