### PR TITLE
Remove Concurrent WriteFF Test

### DIFF
--- a/test/basics/aligned_writeFF_basic.c
+++ b/test/basics/aligned_writeFF_basic.c
@@ -41,30 +41,6 @@ static aligned_t alignedWriteFF_iters(void *arg)
     return 0;
 }
 
-// Test that concurrent writeFFs work and that no tearing occurs
-static void testConcurrentWriteFF(void)
-{
-    int num_writers = (int)qthread_num_workers()/2;
-    if (num_writers <= 1) num_writers = 2;
-    aligned_t rets[num_writers*2];
-    concurrent_t = 0;
-    qthread_fill(&concurrent_t);
-    
-
-    for (int i=0; i<num_writers; i++) {
-      qthread_fork(alignedWriteFF_iters, (void*)ALL_ZEROS, &rets[i]);
-      qthread_fork(alignedWriteFF_iters, (void*)ALL_ONES, &rets[i+num_writers]);
-    }
-
-    for (int i=0; i<num_writers*2; i++) {
-      qthread_readFF(&rets[i], &rets[i]);
-    }
-
-    iprintf("concurrent_t=%x\n", concurrent_t);
-    assert((concurrent_t == ALL_ZEROS) || (concurrent_t == ALL_ONES));
-    assert(qthread_feb_status(&concurrent_t) == 1);
-}
-
 int main(int argc,
          char *argv[])
 {
@@ -74,7 +50,6 @@ int main(int argc,
     iprintf("  %i threads total\n", qthread_num_workers());
 
     testBasicWriteFF();
-    testConcurrentWriteFF();
 
     return 0;
 }


### PR DESCRIPTION
This test basically just tests that if you create a data race with our APIs it behaves correct WRT the underlying memory consistency guarantees from the architecture. As might be expected, the thread sanitizer doesn't like that, so I propose we at least remove this test.

I'd like to remove WriteFF entirely since the use-case is dubious (see https://github.com/sandialabs/qthreads/issues/220), but let's at least remove this bizarre test in the meantime.