### PR TITLE
Skip Concurrent WriteFF Test When Thread Sanitizer Is Enabled

### DIFF
--- a/test/basics/aligned_writeFF_basic.c
+++ b/test/basics/aligned_writeFF_basic.c
@@ -9,6 +9,12 @@
 #include <qthread/qthread.h>
 #include "argparsing.h"
 
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define SKIP_CONCURRENT_WRITEFF_TEST
+#endif
+#endif
+
 // Test that a writeFF on a full var performs the write, and leaves the FEB
 // state untouched. 
 static void testBasicWriteFF(void) 
@@ -31,6 +37,9 @@ static void testBasicWriteFF(void)
 #define ALL_ZEROS 0
 #define ITERS_PER_WORKER 10000
 
+// This test deliberately creates a race condition, so
+// don't run it when thread sanitizer is enabled.
+#ifndef SKIP_CONCURRENT_WRITEFF_TEST
 static aligned_t concurrent_t;
 static aligned_t alignedWriteFF_iters(void *arg)
 {
@@ -64,6 +73,7 @@ static void testConcurrentWriteFF(void)
     assert((concurrent_t == ALL_ZEROS) || (concurrent_t == ALL_ONES));
     assert(qthread_feb_status(&concurrent_t) == 1);
 }
+#endif
 
 int main(int argc,
          char *argv[])
@@ -74,7 +84,9 @@ int main(int argc,
     iprintf("  %i threads total\n", qthread_num_workers());
 
     testBasicWriteFF();
+#ifndef SKIP_CONCURRENT_WRITEFF_TEST
     testConcurrentWriteFF();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
This is an alternative to https://github.com/sandialabs/qthreads/pull/221.