### PR TITLE
Explicit Atomics For Incr Fallback Implementations

### DIFF
--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -3,6 +3,7 @@
 
 #include <errno.h>                     /* for ENOMEM */
 
+#include <stdatomic.h>
 #include <limits.h>                    /* for UINT_MAX (C89) */
 #include "qthread-int.h"               /* for uint32_t and uint64_t */
 #include "common.h"                    /* important configuration options */
@@ -674,7 +675,7 @@ static QINLINE float qthread_fincr(float *operand,
     } oldval, newval, res;
 
     do {
-        oldval.f = *(volatile float *)operand;
+        oldval.f = atomic_load_explicit((_Atomic float *)operand, memory_order_relaxed);
         newval.f = oldval.f + incr;
         res.i    = __sync_val_compare_and_swap((uint32_t *)operand, oldval.i, newval.i);
     } while (res.i != oldval.i);       /* if res!=old, the calc is out of date */
@@ -830,7 +831,7 @@ static QINLINE double qthread_dincr(double *operand,
     } oldval, newval, res;
 
     do {
-        oldval.d = *(volatile double *)operand;
+        oldval.d = atomic_load_explicit((_Atomic double *)operand, memory_order_relaxed);
         newval.d = oldval.d + incr;
         res.i    = __sync_val_compare_and_swap((uint64_t *)operand, oldval.i, newval.i);
     } while (res.i != oldval.i);       /* if res!=old, the calc is out of date */

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -3,7 +3,16 @@
 
 #include <errno.h>                     /* for ENOMEM */
 
+#if defined(__cplusplus) && __cplusplus < 202302L
+#include <atomic>
+#define QT_Atomic(T) std::atomic<T>
+using std::atomic_load_explicit;
+using std::memory_order_relaxed;
+#else
 #include <stdatomic.h>
+#define QT_Atomic(T) _Atomic(T)
+#endif
+
 #include <limits.h>                    /* for UINT_MAX (C89) */
 #include "qthread-int.h"               /* for uint32_t and uint64_t */
 #include "common.h"                    /* important configuration options */
@@ -675,7 +684,7 @@ static QINLINE float qthread_fincr(float *operand,
     } oldval, newval, res;
 
     do {
-        oldval.f = atomic_load_explicit((_Atomic float *)operand, memory_order_relaxed);
+        oldval.f = atomic_load_explicit((QT_Atomic(float) *)operand, memory_order_relaxed);
         newval.f = oldval.f + incr;
         res.i    = __sync_val_compare_and_swap((uint32_t *)operand, oldval.i, newval.i);
     } while (res.i != oldval.i);       /* if res!=old, the calc is out of date */
@@ -831,7 +840,7 @@ static QINLINE double qthread_dincr(double *operand,
     } oldval, newval, res;
 
     do {
-        oldval.d = atomic_load_explicit((_Atomic double *)operand, memory_order_relaxed);
+        oldval.d = atomic_load_explicit((QT_Atomic(double) *)operand, memory_order_relaxed);
         newval.d = oldval.d + incr;
         res.i    = __sync_val_compare_and_swap((uint64_t *)operand, oldval.i, newval.i);
     } while (res.i != oldval.i);       /* if res!=old, the calc is out of date */


### PR DESCRIPTION
Note: I think these functions should be totally rewritten using C11 atomics later (see #225), but this is just a minimal fix for #224.