### PR TITLE
Fix Intermittent Stackleft Crash With Thread Sanitizer

### DIFF
--- a/test/basics/qthread_stackleft.c
+++ b/test/basics/qthread_stackleft.c
@@ -20,6 +20,20 @@ static aligned_t alldone;
 #define STACKLEFT_NOINLINE
 #endif
 
+// Macro for excluding a function from thread sanitizer.
+// Currently this is just used for qt_swapctxt.
+// Something about thread sanitizer's instrumentation is
+// incompatible with our context switching.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define QT_SKIP_THREAD_SANITIZER __attribute__((disable_sanitizer_instrumentation))
+#else
+#define QT_SKIP_THREAD_SANITIZER
+#endif
+#else
+#define QT_SKIP_THREAD_SANITIZER
+#endif
+
 static STACKLEFT_NOINLINE size_t thread2(size_t left,
                                          size_t depth)
 {
@@ -36,7 +50,7 @@ static STACKLEFT_NOINLINE size_t thread2(size_t left,
     return 1;
 }
 
-static aligned_t thread(void *arg)
+static QT_SKIP_THREAD_SANITIZER aligned_t thread(void *arg)
 {
     int me = qthread_id();
     size_t foo = qthread_stackleft();


### PR DESCRIPTION
The intermittent failure with thread sanitizer can be eliminated by just getting rid of a little bit of the instrumentation (similar to #231). Given the slight incompatibility I already saw in #231 and the fact that this is not at all an invasive change I'm inclined to call this good enough.

While working on stackleft I also changed it to use `__builtin_frame_address(0)` instead of taking the address of a local variable to estimate the stack pointer since that seems like it'll be more reliable in the long run.