### PR TITLE
Thread Sanitizer Interop

### DIFF
--- a/include/qt_qthread_struct.h
+++ b/include/qt_qthread_struct.h
@@ -3,6 +3,12 @@
 
 #include <stdatomic.h>
 
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#include <sanitizer/tsan_interface.h>
+#endif
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -66,6 +72,11 @@ struct qthread_runtime_data_s {
 #ifdef QTHREAD_OMP_AFFINITY
   /* affinity for children created by this task */
   qthread_shepherd_id_t child_affinity;
+#endif
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+  void *_Atomic tsan_fiber;
+#endif
 #endif
 };
 

--- a/include/qthread_innards.h
+++ b/include/qthread_innards.h
@@ -48,6 +48,11 @@ typedef struct qlib_s {
 #ifdef QTHREAD_USE_VALGRIND
   unsigned int valgrind_masterstack_id;
 #endif
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+  void *tsan_main_fiber;
+#endif
+#endif
 
   /* assigns a unique thread_id mostly for debugging! */
   aligned_t max_thread_id;


### PR DESCRIPTION
This adds the API calls needed to help the thread sanitizer correctly carry its happens-before relationships across context swaps.