### PR TITLE
Adjust FEB Fences

### DIFF
--- a/test/basics/hello_world.c
+++ b/test/basics/hello_world.c
@@ -30,7 +30,7 @@ int main(int   argc,
     iprintf("%i shepherds...\n", qthread_num_shepherds());
     iprintf("  %i threads total\n", qthread_num_workers());
 
-    status = qthread_fork(greeter, (void*)123456789, &return_value);
+    status = qthread_fork(greeter, NULL, &return_value);
     assert(status == QTHREAD_SUCCESS);
 
     int ret = qthread_readFF(NULL, &return_value);


### PR DESCRIPTION
Careful review appreciated for this one in particular.

This changes the implementation of FEBs so that a memory fence occurs even when the output value passed to the FEB routine is null. This matters because prior to this change, there's not necessarily a guaranteed fence implied by calls like `readFF` and the tests frequently use `readFF` to decide that it's safe to read some value that may be completely distinct from the FEB that's been marked as full.