### PR TITLE
Update to latest available freebsd image in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ osx_m1_task:
 
 freebsd_task:
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-14-0
   timeout_in: 5m
   matrix:
     env:


### PR DESCRIPTION
The old image we were using is no longer available and there's a new one out now, so we're updating to testing on freebsd 14.