### PR TITLE
Restore fastcontext support for big-endian PPC64

### DIFF
--- a/src/fastcontext/context.c
+++ b/src/fastcontext/context.c
@@ -27,7 +27,11 @@ void INTERNAL qt_makectxt(uctxt_t *ucp, void (*func)(void), int argc, ...) {
   tos = (unsigned long *)ucp->uc_stack.ss_sp +
         ucp->uc_stack.ss_size / sizeof(unsigned long);
   sp = tos - 16;
+#if defined __BIG_ENDIAN__ || defined _BIG_ENDIAN
+  ucp->mc.pc = *(long*)func;
+#else
   ucp->mc.pc = (long)func;
+#endif
   ucp->mc.sp = (long)sp;
   va_start(arg, argc);
   ucp->mc.r3 = va_arg(arg, long);


### PR DESCRIPTION
### Background:

I conduct automated regression testing of Chapel using GASNet-EX for multi-locale support on a variety of systems.
Recently my testing on big-endian PPC64/Linux began failing (SEGV early in startup).
Based on the last-good/first-bad test dates, Brad Chamberlain identified Chapel's update of Qthreads from 1.20 to 1.21 as a likely cause. 

I have confirmed that if I build the 1.21 release of Qthreads on a big-endian PPC64 it fails in `make check`, with a SEGV in nearly every test.  However, `make check` passes fine with the 1.20 release.

This single-commit PR is necessary and sufficient to allow the `hello_world` test (among others) to PASS.  
However, this is not sufficient to get a clean run of `make check`.
I, unfortunately, cannot devote additional time to addressing whatever else is wrong.
I hope to reach out via email to the Qthreads team (probably next week) to provide access to a BE PPC64 system.

Please note that I am making this contribution under the assumption that there is a desire to retain (restore, actually) support for BE PPC64/Linux.  However, if the Qthreads team determines that dropping support for this target is the appropriate action, I will not lobby against such a decision.

### Commits:
- Restore fastcontext support for big-endian PPC64

  This commit restores support in fastcontext for the "function descriptor" of the 64-bit PowerPC ELF ABI, which is common to both AIX and Linux on big-endian PPC64.  It appears to have been unintentionally removed along with AIX support in pull request #277 due to the (unfortunate) choice of `QTHREAD_PPC_ABI_AIX` to identify this ABI.  
  
  Partially reverts 4f3031ce17a79be45ef5f38a7f711c972bf17cd4