### PR TITLE
Minor Performance Regression Fixes

### DIFF
--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -90,15 +90,15 @@ void qt_spin_exclusive_unlock(qt_spin_exclusive_t *);
   { (x)->u = 0; }
 #define QTHREAD_TRYLOCK_LOCK(x)                                                \
   {                                                                            \
-    uint32_t val = qthread_incr(&(x)->s.users, 1);                             \
+    uint32_t val =                                                             \
+      atomic_fetch_add_explicit(&(x)->s.users, 1, memory_order_relaxed);       \
     while (val != atomic_load_explicit((_Atomic uint32_t *)&(x)->s.ticket,     \
                                        memory_order_acquire))                  \
       SPINLOCK_BODY();                                                         \
   }
 #define QTHREAD_TRYLOCK_UNLOCK(x)                                              \
   do {                                                                         \
-    atomic_thread_fence(memory_order_release);                                 \
-    qthread_incr(&(x)->s.ticket, 1); /* allow next guy's turn */               \
+    atomic_fetch_add_explicit(&(x)->s.ticket, 1, memory_order_release);        \
   } while (0)
 #define QTHREAD_TRYLOCK_DESTROY(x)
 #define QTHREAD_TRYLOCK_DESTROY_PTR(x)

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -87,7 +87,7 @@ using std::memory_order_relaxed;
 
 #include "macros.h"
 
-#define MACHINE_FENCE atomic_thread_fence(memory_order_acq_rel);
+#define MACHINE_FENCE atomic_thread_fence(memory_order_seq_cst);
 
 #if QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64
 #define QTHREAD_SWAPS_IMPLY_ACQ_REL_FENCES

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -472,8 +472,8 @@ typedef union qt_spin_trylock_s {
   aligned_t u;
 
   struct {
-    haligned_t ticket;
-    haligned_t users;
+    QT_Atomic(haligned_t) ticket;
+    QT_Atomic(haligned_t) users;
   } s;
 } qt_spin_trylock_t;
 

--- a/src/io.c
+++ b/src/io.c
@@ -74,7 +74,6 @@ static void qt_blocking_subsystem_internal_freemem(void) { /*{{{*/
 static void *qt_blocking_subsystem_proxy_thread(void *Q_UNUSED(arg)) { /*{{{*/
   while (!atomic_load_explicit(&proxy_exit, memory_order_relaxed)) {
     if (qt_process_blocking_call()) { break; }
-    MACHINE_FENCE;
   }
   atomic_fetch_sub_explicit(&io_worker_count, 1, memory_order_relaxed);
   pthread_exit(NULL);


### PR DESCRIPTION
These are some minor performance fixes to help fix regressions downstream

In particular, this removes an unnecessary thread fence in the IO code, and updates the MACHINE_FENCE macro to use a stronger type of memory fence (since this somehow results in better performance in practice).

The trylock patch is just a simplification that I wrote while attempting to debug the performance regressions. That should be performance neutral.