### PR TITLE
Additional Performance Fixes

### DIFF
--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -87,7 +87,7 @@ using std::memory_order_relaxed;
 
 #include "macros.h"
 
-#define MACHINE_FENCE atomic_thread_fence(memory_order_seq_cst);
+#define MACHINE_FENCE atomic_thread_fence(memory_order_acq_rel);
 
 #if QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64
 #define QTHREAD_SWAPS_IMPLY_ACQ_REL_FENCES


### PR DESCRIPTION
This reverts one of the commits from #314 since it ended up being more harmful than helpful downstream. The Chapel array init/deinit benchmark seems to be very hardware dependent and we don't want to eliminate the big improvements in other applications from the 1.21 release.