### PR TITLE
Default to Hidden Symbol Visibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(qthread SHARED ${QTHREADS_SOURCES})
 target_include_directories(qthread
   PRIVATE "../include"
 )
+set_target_properties(qthread PROPERTIES C_VISIBILITY_PRESET hidden)
 target_link_libraries(qthread PUBLIC Threads::Threads)
 target_include_directories(qthread
   PUBLIC

--- a/src/cacheline.c
+++ b/src/cacheline.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #endif
 
+#include "qt_visibility.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -341,7 +343,7 @@ static void figure_out_cacheline_size(void) { /*{{{ */
 } /*}}} */
 
 /* returns the cache line size */
-int qthread_cacheline(void) { /*{{{ */
+int API_FUNC qthread_cacheline(void) { /*{{{ */
   if (cacheline_bytes == 0) {
     figure_out_cacheline_size();
     if (cacheline_bytes == 0) { /* to cache errors in cacheline detection */

--- a/src/ds/dictionary/dictionary_shavit.c
+++ b/src/ds/dictionary/dictionary_shavit.c
@@ -340,11 +340,13 @@ qt_hash_put(qt_hash h, qt_key_t key, void *value, int put_choice) {
   return ret->value;
 }
 
-void *qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
   return qt_hash_put(dict, key, value, PUT_ALWAYS);
 }
 
-void *qt_dictionary_put_if_absent(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put_if_absent(qt_dictionary *dict,
+                                           void *key,
+                                           void *value) {
   return qt_hash_put(dict, key, value, PUT_IF_ABSENT);
 }
 
@@ -366,7 +368,7 @@ static inline void *qt_hash_get(qt_hash h, qt_key_t const key) {
     &(h->B[bucket]), so_regularkey(lkey), key, NULL, NULL, NULL, h->op_equals);
 }
 
-void *qt_dictionary_get(qt_dictionary *dict, void *key) {
+void *API_FUNC qt_dictionary_get(qt_dictionary *dict, void *key) {
   return qt_hash_get(dict, key);
 }
 
@@ -390,7 +392,7 @@ static inline int qt_hash_remove(qt_hash h, qt_key_t const key) {
   return 1;
 }
 
-void *qt_dictionary_delete(qt_dictionary *dict, void *key) {
+void *API_FUNC qt_dictionary_delete(qt_dictionary *dict, void *key) {
   void *val = qt_hash_get(dict, key); // TODO : this is inefficient!
   int ret = qt_hash_remove(dict, key);
 
@@ -470,9 +472,9 @@ static inline qt_hash qt_hash_create(qt_dict_key_equals_f eq,
   return tmp;
 }
 
-qt_dictionary *qt_dictionary_create(qt_dict_key_equals_f eq,
-                                    qt_dict_hash_f hash,
-                                    qt_dict_cleanup_f cleanup) {
+qt_dictionary *API_FUNC qt_dictionary_create(qt_dict_key_equals_f eq,
+                                             qt_dict_hash_f hash,
+                                             qt_dict_cleanup_f cleanup) {
   return qt_hash_create(eq, hash, cleanup);
 }
 
@@ -497,7 +499,7 @@ static inline void qt_hash_destroy(qt_hash h) {
   FREE(h, sizeof(qt_hash));
 }
 
-void qt_dictionary_destroy(qt_dictionary *d) { qt_hash_destroy(d); }
+void API_FUNC qt_dictionary_destroy(qt_dictionary *d) { qt_hash_destroy(d); }
 
 /*
  * void qt_hash_destroy_deallocate(qt_hash                h,
@@ -555,7 +557,8 @@ struct qt_dictionary_iterator {
   int bkt;         // = -1 if iterator is newly created; =1 otherwise.
 };
 
-qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_create(qt_dictionary *dict) {
   if (dict == NULL) { return ERROR; }
   qt_dictionary_iterator *it =
     (qt_dictionary_iterator *)MALLOC(sizeof(qt_dictionary_iterator));
@@ -565,7 +568,7 @@ qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
   return it;
 }
 
-void qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
+void API_FUNC qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
   if (it == NULL) { return; }
   FREE(it, sizeof(qt_dictionary_iterator));
 }
@@ -592,7 +595,7 @@ qt_dictionary_iterator_next_element(qt_dictionary_iterator *it) {
   return it->crt;
 }
 
-list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
+list_entry *API_FUNC qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   list_entry *ret = qt_dictionary_iterator_next_element(it);
 
   while (ret != ERROR && ret != NULL && ret->key == NULL) {
@@ -601,27 +604,29 @@ list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   return ret;
 }
 
-list_entry *qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
+list_entry *API_FUNC
+qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
   if ((it == NULL) || (it->dict == NULL)) { return ERROR; }
   qt_dictionary *h = it->dict;
   if ((h->count == 0) || (it->crt == UNINITIALIZED)) { return NULL; }
   return it->crt;
 }
 
-qt_dictionary_iterator *qt_dictionary_end(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC qt_dictionary_end(qt_dictionary *dict) {
   qt_dictionary_iterator *ret = qt_dictionary_iterator_create(dict);
 
   ret->bkt = 1;
   return ret;
 }
 
-int qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
-                                  qt_dictionary_iterator *b) {
+int API_FUNC qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
+                                           qt_dictionary_iterator *b) {
   if ((a == NULL) || (b == NULL)) { return a == b; }
   return (a->crt == b->crt) && (a->dict == b->dict) && (a->bkt == b->bkt);
 }
 
-qt_dictionary_iterator *qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
   if (b == NULL) { return NULL; }
   qt_dictionary_iterator *ret = qt_dictionary_iterator_create(b->dict);
   if ((ret == NULL) || (ret == ERROR)) { return NULL; }

--- a/src/ds/dictionary/dictionary_simple.c
+++ b/src/ds/dictionary/dictionary_simple.c
@@ -102,9 +102,9 @@ static int qthread_library_initialized = 1;
 extern int qthread_library_initialized;
 #endif
 
-qt_dictionary *qt_dictionary_create(qt_dict_key_equals_f eq,
-                                    qt_dict_hash_f hash,
-                                    qt_dict_cleanup_f cleanup) {
+qt_dictionary *API_FUNC qt_dictionary_create(qt_dict_key_equals_f eq,
+                                             qt_dict_hash_f hash,
+                                             qt_dict_cleanup_f cleanup) {
   assert(qthread_library_initialized &&
          "Need to initialize qthreads before using the dictionary");
   qt_dictionary *ret = (qt_dictionary *)MALLOC(sizeof(qt_dictionary));
@@ -120,7 +120,7 @@ qt_dictionary *qt_dictionary_create(qt_dict_key_equals_f eq,
   return ret;
 }
 
-void qt_dictionary_destroy(qt_dictionary *d) {
+void API_FUNC qt_dictionary_destroy(qt_dictionary *d) {
   int i;
 
   for (i = 0; i < NO_BUCKETS; i++) {
@@ -256,15 +256,17 @@ void *qt_dictionary_put_helper(qt_dictionary *dict,
 }
 #endif /* ifdef DICTIONARY_ADD_TO_HEAD */
 
-void *qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
   return qt_dictionary_put_helper(dict, key, value, PUT_ALWAYS);
 }
 
-void *qt_dictionary_put_if_absent(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put_if_absent(qt_dictionary *dict,
+                                           void *key,
+                                           void *value) {
   return qt_dictionary_put_helper(dict, key, value, PUT_IF_ABSENT);
 }
 
-void *qt_dictionary_get(qt_dictionary *dict, void *key) {
+void *API_FUNC qt_dictionary_get(qt_dictionary *dict, void *key) {
   int hash = dict->op_hash(key);
   int bucket = GET_BUCKET(hash);
 
@@ -283,7 +285,7 @@ void *qt_dictionary_get(qt_dictionary *dict, void *key) {
   return NULL;
 }
 
-void *qt_dictionary_delete(qt_dictionary *dict, void *key) {
+void *API_FUNC qt_dictionary_delete(qt_dictionary *dict, void *key) {
   void *to_ret = NULL;
   list_entry *to_free = NULL;
   int hash = dict->op_hash(key);
@@ -340,7 +342,8 @@ void *qt_dictionary_delete(qt_dictionary *dict, void *key) {
   return to_ret;
 }
 
-qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_create(qt_dictionary *dict) {
   if ((dict == NULL) || (dict->content == NULL)) { return ERROR; }
   qt_dictionary_iterator *it =
     (qt_dictionary_iterator *)MALLOC(sizeof(qt_dictionary_iterator));
@@ -353,12 +356,12 @@ qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
   return it;
 }
 
-void qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
+void API_FUNC qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
   if (it == NULL) { return; }
   FREE(it, sizeof(qt_dictionary_iterator));
 }
 
-list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
+list_entry *API_FUNC qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   if ((it == NULL) || (it->dict == NULL) || (it->dict->content == NULL)) {
     return ERROR;
   }
@@ -400,7 +403,8 @@ list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   return NULL;
 }
 
-list_entry *qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
+list_entry *API_FUNC
+qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
   if ((it == NULL) || (it->dict == NULL) || (it->dict->content == NULL)) {
     printf(" Inside dictionary get, found NULL, will return ERROR\n");
     return ERROR;
@@ -409,7 +413,7 @@ list_entry *qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
   return it->crt;
 }
 
-qt_dictionary_iterator *qt_dictionary_end(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC qt_dictionary_end(qt_dictionary *dict) {
   if ((dict == NULL) || (dict->content == NULL)) { return NULL; }
   qt_dictionary_iterator *it = qt_dictionary_iterator_create(dict);
   it->crt = NULL;
@@ -418,13 +422,14 @@ qt_dictionary_iterator *qt_dictionary_end(qt_dictionary *dict) {
   return it;
 }
 
-int qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
-                                  qt_dictionary_iterator *b) {
+int API_FUNC qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
+                                           qt_dictionary_iterator *b) {
   if ((a == NULL) || (b == NULL)) { return a == b; }
   return (a->crt == b->crt) && (a->dict == b->dict) && (a->bkt == b->bkt);
 }
 
-qt_dictionary_iterator *qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
   if (b == NULL) { return NULL; }
   qt_dictionary_iterator *ret = qt_dictionary_iterator_create(b->dict);
   if ((ret == NULL) || (ret == ERROR)) { return NULL; }

--- a/src/ds/dictionary/dictionary_trie.c
+++ b/src/ds/dictionary/dictionary_trie.c
@@ -107,9 +107,9 @@ static inline qt_hash qt_hash_create(qt_dict_key_equals_f eq,
   return tmp;
 }
 
-qt_dictionary *qt_dictionary_create(qt_dict_key_equals_f eq,
-                                    qt_dict_hash_f hash,
-                                    qt_dict_cleanup_f cleanup) {
+qt_dictionary *API_FUNC qt_dictionary_create(qt_dict_key_equals_f eq,
+                                             qt_dict_hash_f hash,
+                                             qt_dict_cleanup_f cleanup) {
   return qt_hash_create(eq, hash, cleanup);
 }
 
@@ -227,7 +227,7 @@ static void destroy_element(hash_entry *element, qt_dict_cleanup_f f) {
   FREE(element, sizeof(hash_entry));
 }
 
-void qt_dictionary_destroy(qt_hash h) {
+void API_FUNC qt_dictionary_destroy(qt_hash h) {
   assert(h);
   assert(h->spines);
   for (size_t i = 0; i < BASE_SPINE_LENGTH; ++i) {
@@ -401,17 +401,19 @@ void *qt_hash_put_helper(qt_dictionary *h,
   } while (1);
 }
 
-void *qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put(qt_dictionary *dict, void *key, void *value) {
   return qt_hash_put_helper(dict, key, value, PUT_ALWAYS);
 }
 
-void *qt_dictionary_put_if_absent(qt_dictionary *dict, void *key, void *value) {
+void *API_FUNC qt_dictionary_put_if_absent(qt_dictionary *dict,
+                                           void *key,
+                                           void *value) {
   return qt_hash_put_helper(dict, key, value, PUT_IF_ABSENT);
 }
 
-int qt_dictionary_remove(qt_dictionary *h, qt_key_t const key);
+int API_FUNC qt_dictionary_remove(qt_dictionary *h, qt_key_t const key);
 
-int qt_dictionary_remove(qt_dictionary *h, qt_key_t const key) {
+int API_FUNC qt_dictionary_remove(qt_dictionary *h, qt_key_t const key) {
   uint64_t lkey = (uint64_t)(uintptr_t)(h->op_hash(key));
 
   HASH_KEY(lkey);
@@ -493,7 +495,7 @@ int qt_dictionary_remove(qt_dictionary *h, qt_key_t const key) {
   } while (1);
 }
 
-void *qt_dictionary_delete(qt_dictionary *dict, void *key) {
+void *API_FUNC qt_dictionary_delete(qt_dictionary *dict, void *key) {
   void *val = qt_dictionary_get(dict, key); // TODO : this is inefficient!
   int ret = qt_dictionary_remove(dict, key);
 
@@ -504,7 +506,7 @@ void *qt_dictionary_delete(qt_dictionary *dict, void *key) {
   }
 }
 
-void *qt_dictionary_get(qt_dictionary *h, qt_key_t const key) {
+void *API_FUNC qt_dictionary_get(qt_dictionary *h, qt_key_t const key) {
   uint64_t lkey = (uint64_t)(uintptr_t)(h->op_hash(key));
 
   HASH_KEY(lkey);
@@ -612,7 +614,8 @@ struct qt_dictionary_iterator {
   int base_index;
 };
 
-qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_create(qt_dictionary *dict) {
   if (dict == NULL) { return ERROR; }
   qt_dictionary_iterator *it =
     (qt_dictionary_iterator *)MALLOC(sizeof(qt_dictionary_iterator));
@@ -624,12 +627,12 @@ qt_dictionary_iterator *qt_dictionary_iterator_create(qt_dictionary *dict) {
   return it;
 }
 
-void qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
+void API_FUNC qt_dictionary_iterator_destroy(qt_dictionary_iterator *it) {
   if (it == NULL) { return; }
   FREE(it, sizeof(qt_dictionary_iterator));
 }
 
-list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
+list_entry *API_FUNC qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   if ((it == NULL) || (it->dict == NULL)) { return ERROR; }
 
   if ((it->crt != NULL) && (it->crt->next != NULL)) {
@@ -671,25 +674,27 @@ list_entry *qt_dictionary_iterator_next(qt_dictionary_iterator *it) {
   return NULL;
 }
 
-list_entry *qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
+list_entry *API_FUNC
+qt_dictionary_iterator_get(qt_dictionary_iterator const *it) {
   if ((it == NULL) || (it->dict == NULL)) { return ERROR; }
   return it->crt;
 }
 
-qt_dictionary_iterator *qt_dictionary_end(qt_dictionary *dict) {
+qt_dictionary_iterator *API_FUNC qt_dictionary_end(qt_dictionary *dict) {
   qt_dictionary_iterator *ret = qt_dictionary_iterator_create(dict);
 
   ret->bkt = ret->dict->maxspines;
   return ret;
 }
 
-int qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
-                                  qt_dictionary_iterator *b) {
+int API_FUNC qt_dictionary_iterator_equals(qt_dictionary_iterator *a,
+                                           qt_dictionary_iterator *b) {
   if ((a == NULL) || (b == NULL)) { return a == b; }
   return (a->crt == b->crt) && (a->dict == b->dict) && (a->bkt == b->bkt);
 }
 
-qt_dictionary_iterator *qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
+qt_dictionary_iterator *API_FUNC
+qt_dictionary_iterator_copy(qt_dictionary_iterator *b) {
   if (b == NULL) { return NULL; }
   qt_dictionary_iterator *ret = qt_dictionary_iterator_create(b->dict);
   if ((ret == NULL) || (ret == ERROR)) { return NULL; }

--- a/src/ds/qarray.c
+++ b/src/ds/qarray.c
@@ -392,24 +392,25 @@ static qarray *qarray_create_internal(size_t const count,
   return NULL;
 } /*}}} */
 
-qarray *qarray_create(size_t const count, size_t const obj_size) { /*{{{ */
+qarray *API_FUNC qarray_create(size_t const count,
+                               size_t const obj_size) { /*{{{ */
   return qarray_create_internal(count, obj_size, FIXED_HASH, 0, 0);
 } /*}}} */
 
-qarray *qarray_create_tight(size_t const count,
-                            size_t const obj_size) { /*{{{ */
+qarray *API_FUNC qarray_create_tight(size_t const count,
+                                     size_t const obj_size) { /*{{{ */
   return qarray_create_internal(count, obj_size, FIXED_HASH, 1, 0);
 } /*}}} */
 
-qarray *qarray_create_configured(size_t const count,
-                                 size_t const obj_size,
-                                 distribution_t const d,
-                                 char const tight,
-                                 int const seg_pages) { /*{{{ */
+qarray *API_FUNC qarray_create_configured(size_t const count,
+                                          size_t const obj_size,
+                                          distribution_t const d,
+                                          char const tight,
+                                          int const seg_pages) { /*{{{ */
   return qarray_create_internal(count, obj_size, d, tight, seg_pages);
 } /*}}} */
 
-void qarray_destroy(qarray *a) { /*{{{ */
+void API_FUNC qarray_destroy(qarray *a) { /*{{{ */
   qassert_retvoid((a != NULL));
   qassert_retvoid((a->base_ptr != NULL));
   switch (a->dist_type) {
@@ -825,10 +826,10 @@ qarray_loop_strider_exit:
   return 0;
 } /*}}} */
 
-void qarray_iter(qarray *a,
-                 size_t const startat,
-                 size_t const stopat,
-                 qthread_f func) { /*{{{ */
+void API_FUNC qarray_iter(qarray *a,
+                          size_t const startat,
+                          size_t const stopat,
+                          qthread_f func) { /*{{{ */
   aligned_t donecount = 0;
   struct qarray_func_wrapper_args qfwa = {
     {NULL}, a, NULL, &donecount, startat, stopat};
@@ -879,11 +880,11 @@ void qarray_iter(qarray *a,
   }
 } /*}}} */
 
-void qarray_iter_loop(qarray *a,
-                      size_t const startat,
-                      size_t const stopat,
-                      qa_loop_f func,
-                      void *arg) { /*{{{ */
+void API_FUNC qarray_iter_loop(qarray *a,
+                               size_t const startat,
+                               size_t const stopat,
+                               qa_loop_f func,
+                               void *arg) { /*{{{ */
   aligned_t donecount = 0;
   struct qarray_func_wrapper_args qfwa = {
     {func}, a, arg, &donecount, startat, stopat};
@@ -1027,14 +1028,14 @@ void qarray_iter_constloop(qarray const *a,
   }
 } /*}}} */
 
-void qarray_iter_loopaccum(qarray *a,
-                           size_t const startat,
-                           size_t const stopat,
-                           qa_loopr_f func,
-                           void *arg,
-                           void *ret,
-                           size_t const retsize,
-                           qt_accum_f acc) { /*{{{ */
+void API_FUNC qarray_iter_loopaccum(qarray *a,
+                                    size_t const startat,
+                                    size_t const stopat,
+                                    qa_loopr_f func,
+                                    void *arg,
+                                    void *ret,
+                                    size_t const retsize,
+                                    qt_accum_f acc) { /*{{{ */
   qassert_retvoid((a != NULL));
   qassert_retvoid((func != NULL));
   qassert_retvoid((startat <= stopat));

--- a/src/ds/qdqueue.c
+++ b/src/ds/qdqueue.c
@@ -264,7 +264,7 @@ qdqueue_internal_getneighbors(qthread_shepherd_id_t shep,
 } /*}}} */
 
 /* Create a new qdqueue */
-qdqueue_t *qdqueue_create(void) { /*{{{ */
+qdqueue_t *API_FUNC qdqueue_create(void) { /*{{{ */
   qdqueue_t *ret;
   qthread_shepherd_id_t curshep;
   int **sheparray;
@@ -328,7 +328,7 @@ qdqueue_t *qdqueue_create(void) { /*{{{ */
 } /*}}} */
 
 /* destroy that queue */
-int qdqueue_destroy(qdqueue_t *q) { /*{{{ */
+int API_FUNC qdqueue_destroy(qdqueue_t *q) { /*{{{ */
   qthread_shepherd_id_t i;
 
   qassert_ret((q != NULL), QTHREAD_BADARGS);
@@ -351,7 +351,7 @@ int qdqueue_destroy(qdqueue_t *q) { /*{{{ */
 } /*}}} */
 
 /* enqueue something in the queue */
-int qdqueue_enqueue(qdqueue_t *q, void *elem) { /*{{{ */
+int API_FUNC qdqueue_enqueue(qdqueue_t *q, void *elem) { /*{{{ */
   int stat;
   struct qdsubqueue_s *myq;
 
@@ -422,7 +422,7 @@ int qdqueue_enqueue_there(qdqueue_t *q,
 } /*}}} */
 
 /* dequeue something from the queue (returns NULL for an empty queue) */
-void *qdqueue_dequeue(qdqueue_t *q) { /*{{{ */
+void *API_FUNC qdqueue_dequeue(qdqueue_t *q) { /*{{{ */
   struct qdsubqueue_s *myq;
   void *ret;
 
@@ -488,7 +488,7 @@ void *qdqueue_dequeue(qdqueue_t *q) { /*{{{ */
 } /*}}} */
 
 /* returns 1 if the queue is empty, 0 otherwise */
-int qdqueue_empty(qdqueue_t *q) { /*{{{ */
+int API_FUNC qdqueue_empty(qdqueue_t *q) { /*{{{ */
   struct qdsubqueue_s *myq;
 
   qassert_ret(q, 0);

--- a/src/ds/qlfqueue.c
+++ b/src/ds/qlfqueue.c
@@ -39,7 +39,7 @@ static void qlfqueue_internal_cleanup(void) {
  * http://www.research.ibm.com/people/m/michael/ieeetpds-2004.pdf
  */
 
-qlfqueue_t *qlfqueue_create(void) { /*{{{ */
+qlfqueue_t *API_FUNC qlfqueue_create(void) { /*{{{ */
   qlfqueue_t *q;
 
   if (qlfqueue_node_pool == NULL) {
@@ -69,7 +69,7 @@ qlfqueue_t *qlfqueue_create(void) { /*{{{ */
   return q;
 } /*}}} */
 
-int qlfqueue_destroy(qlfqueue_t *q) { /*{{{ */
+int API_FUNC qlfqueue_destroy(qlfqueue_t *q) { /*{{{ */
   qassert_ret((q != NULL), QTHREAD_BADARGS);
   while (q->head != q->tail) {
     qlfqueue_dequeue(q);
@@ -81,7 +81,7 @@ int qlfqueue_destroy(qlfqueue_t *q) { /*{{{ */
   return QTHREAD_SUCCESS;
 } /*}}} */
 
-int qlfqueue_enqueue(qlfqueue_t *q, void *elem) { /*{{{ */
+int API_FUNC qlfqueue_enqueue(qlfqueue_t *q, void *elem) { /*{{{ */
   qlfqueue_node_t *tail;
   qlfqueue_node_t *next;
   qlfqueue_node_t *node;
@@ -122,7 +122,7 @@ static void qlfqueue_pool_free_wrapper(void *p) { /*{{{*/
   qpool_free(qlfqueue_node_pool, p);
 } /*}}}*/
 
-void *qlfqueue_dequeue(qlfqueue_t *q) { /*{{{ */
+void *API_FUNC qlfqueue_dequeue(qlfqueue_t *q) { /*{{{ */
   void *p = NULL;
   qlfqueue_node_t *head;
   qlfqueue_node_t *tail;
@@ -157,7 +157,7 @@ void *qlfqueue_dequeue(qlfqueue_t *q) { /*{{{ */
   return p;
 } /*}}} */
 
-int qlfqueue_empty(qlfqueue_t *q) { /*{{{ */
+int API_FUNC qlfqueue_empty(qlfqueue_t *q) { /*{{{ */
   qlfqueue_node_t *head;
   qlfqueue_node_t *tail;
   qlfqueue_node_t *next;

--- a/src/ds/qpool.c
+++ b/src/ds/qpool.c
@@ -5,22 +5,24 @@
 /* Internal Headers */
 #include "qt_asserts.h"
 #include "qt_mpool.h"
+#include "qt_visibility.h"
 #include "qthread/qpool.h"
 
-qpool *qpool_create_aligned(size_t const isize, size_t alignment) { /*{{{ */
+qpool *API_FUNC qpool_create_aligned(size_t const isize,
+                                     size_t alignment) { /*{{{ */
   return qt_mpool_create_aligned(isize, alignment);
 } /*}}} */
 
-qpool *qpool_create(size_t const item_size) { /*{{{ */
+qpool *API_FUNC qpool_create(size_t const item_size) { /*{{{ */
   return qpool_create_aligned(item_size, 0);
 } /*}}} */
 
-void *qpool_alloc(qpool *pool) { return qt_mpool_alloc(pool); }
+void *API_FUNC qpool_alloc(qpool *pool) { return qt_mpool_alloc(pool); }
 
-void qpool_free(qpool *restrict pool, void *restrict mem) {
+void API_FUNC qpool_free(qpool *restrict pool, void *restrict mem) {
   qt_mpool_free(pool, mem);
 }
 
-void qpool_destroy(qpool *pool) { qt_mpool_destroy(pool); }
+void API_FUNC qpool_destroy(qpool *pool) { qt_mpool_destroy(pool); }
 
 /* vim:set expandtab: */

--- a/src/ds/qswsrqueue.c
+++ b/src/ds/qswsrqueue.c
@@ -21,7 +21,7 @@ struct qswsrqueue_s { /* typedef'd to qswsrqueue_t */
   void *elements[];
 };
 
-qswsrqueue_t *qswsrqueue_create(size_t elements) { /*{{{ */
+qswsrqueue_t *API_FUNC qswsrqueue_create(size_t elements) { /*{{{ */
   qswsrqueue_t *q;
 
   if ((elements * sizeof(void *)) < CACHELINE_WIDTH) {
@@ -42,14 +42,14 @@ qswsrqueue_t *qswsrqueue_create(size_t elements) { /*{{{ */
   return q;
 } /*}}} */
 
-int qswsrqueue_destroy(qswsrqueue_t *q) { /*{{{ */
+int API_FUNC qswsrqueue_destroy(qswsrqueue_t *q) { /*{{{ */
   qassert_ret((q != NULL), QTHREAD_BADARGS);
   qt_internal_aligned_free(
     q, sizeof(struct qswsrqueue_s) + (q->size * sizeof(void *)));
   return QTHREAD_SUCCESS;
 } /*}}} */
 
-int qswsrqueue_enqueue(qswsrqueue_t *q, void *elem) { /*{{{ */
+int API_FUNC qswsrqueue_enqueue(qswsrqueue_t *q, void *elem) { /*{{{ */
   uint32_t cur_tail = q->tail;
   uint32_t next_tail = (cur_tail + 1) % q->size;
   MACHINE_FENCE;
@@ -78,7 +78,7 @@ int qswsrqueue_enqueue_blocking(qswsrqueue_t *q, void *elem) { /*{{{ */
   } while (1);
 } /*}}} */
 
-void *qswsrqueue_dequeue(qswsrqueue_t *q) { /*{{{ */
+void *API_FUNC qswsrqueue_dequeue(qswsrqueue_t *q) { /*{{{ */
   void *item;
   uint32_t cur_head = q->head;
   MACHINE_FENCE;
@@ -106,7 +106,7 @@ void *qswsrqueue_dequeue_blocking(qswsrqueue_t *q) { /*{{{ */
 } /*}}} */
 
 /* returns 1 if the queue is empty, 0 otherwise */
-int qswsrqueue_empty(qswsrqueue_t *q) { /*{{{ */
+int API_FUNC qswsrqueue_empty(qswsrqueue_t *q) { /*{{{ */
   return (q->head == q->tail);
 } /*}}} */
 

--- a/src/patterns/allpairs.c
+++ b/src/patterns/allpairs.c
@@ -315,18 +315,20 @@ static void qt_allpairs_internal(qarray const *array1,
 #endif
 }
 
-void qt_allpairs_output(qarray const *array1,
-                        qarray const *array2,
-                        dist_out_f distfunc,
-                        void *restrict *restrict output,
-                        size_t outsize) {
+void API_FUNC qt_allpairs_output(qarray const *array1,
+                                 qarray const *array2,
+                                 dist_out_f distfunc,
+                                 void *restrict *restrict output,
+                                 size_t outsize) {
   union distfuncunion df;
 
   df.od = distfunc;
   qt_allpairs_internal(array1, array2, df, 1, output, outsize);
 }
 
-void qt_allpairs(qarray const *array1, qarray const *array2, dist_f distfunc) {
+void API_FUNC qt_allpairs(qarray const *array1,
+                          qarray const *array2,
+                          dist_f distfunc) {
   const union distfuncunion df = {distfunc};
 
   qt_allpairs_internal(array1, array2, df, 0, NULL, 0);

--- a/src/qalloc.c
+++ b/src/qalloc.c
@@ -188,11 +188,11 @@ static inline void *qalloc_getfile(off_t const filesize,
   return ret;
 } /*}}} */
 
-void *qalloc_makestatmap(off_t const filesize,
-                         void *addr,
-                         char const *filename,
-                         size_t itemsize,
-                         size_t const streams) { /*{{{ */
+void *API_FUNC qalloc_makestatmap(off_t const filesize,
+                                  void *addr,
+                                  char const *filename,
+                                  size_t itemsize,
+                                  size_t const streams) { /*{{{ */
   void *set, *ret;
 
   ret = qalloc_getfile(filesize, addr, filename, &set);
@@ -272,10 +272,10 @@ void *qalloc_makestatmap(off_t const filesize,
   return NULL;
 } /*}}} */
 
-void *qalloc_makedynmap(off_t const filesize,
-                        void *addr,
-                        char const *filename,
-                        size_t const streams) { /*{{{ */
+void *API_FUNC qalloc_makedynmap(off_t const filesize,
+                                 void *addr,
+                                 char const *filename,
+                                 size_t const streams) { /*{{{ */
   void *set, *ret;
 
   ret = qalloc_getfile(filesize, addr, filename, &set);
@@ -376,7 +376,7 @@ void *qalloc_loadmap(char const *filename) { /*{{{ */
   }
 } /*}}} */
 
-void qalloc_cleanup(void) { /*{{{ */
+void API_FUNC qalloc_cleanup(void) { /*{{{ */
   qalloc_checkpoint();
   while (mmaps) {
     struct mapinfo_s *m;
@@ -406,7 +406,7 @@ void qalloc_cleanup(void) { /*{{{ */
  * imbalance (i.e. one thread is making all of the qalloc_malloc() calls).
  * Could probably do more aggressive memory stealing from the next stream if
  * that becomes a problem */
-void *qalloc_statmalloc(struct mapinfo_s *m) { /*{{{ */
+void *API_FUNC qalloc_statmalloc(struct mapinfo_s *m) { /*{{{ */
   pthread_t me = pthread_self();
   size_t stream = (size_t)me % m->streamcount;
   size_t firststream = stream;
@@ -653,7 +653,7 @@ static inline bigblock_header_t *qalloc_find_bigblock_header_entry(
   return bbh;
 } /*}}} */
 
-void *qalloc_dynmalloc(struct dynmapinfo_s *m, size_t size) { /*{{{ */
+void *API_FUNC qalloc_dynmalloc(struct dynmapinfo_s *m, size_t size) { /*{{{ */
   pthread_t me = pthread_self();
   size_t stream = (size_t)me % m->streamcount;
   size_t original_stream;
@@ -764,7 +764,7 @@ void *qalloc_dynmalloc(struct dynmapinfo_s *m, size_t size) { /*{{{ */
   return ret;
 } /*}}} */
 
-void *qalloc_malloc(void *mapinfo, size_t size) { /*{{{ */
+void *API_FUNC qalloc_malloc(void *mapinfo, size_t size) { /*{{{ */
   if (((struct mapinfo_s *)mapinfo)->dynflag == 0) {
     return qalloc_statmalloc((struct mapinfo_s *)mapinfo);
   } else {
@@ -850,7 +850,7 @@ void qalloc_dynfree(void *block, struct dynmapinfo_s *m) { /*{{{ */
   /* XXX: consider freeing unused smallblocks or bigblock header blocks */
 } /*}}} */
 
-void qalloc_free(void *block, void *mapinfo) { /*{{{ */
+void API_FUNC qalloc_free(void *block, void *mapinfo) { /*{{{ */
   if (((struct mapinfo_s *)mapinfo)->dynflag == 0) {
     qalloc_statfree(block, (struct mapinfo_s *)mapinfo);
   } else {
@@ -858,7 +858,7 @@ void qalloc_free(void *block, void *mapinfo) { /*{{{ */
   }
 } /*}}} */
 
-void qalloc_checkpoint(void) { /*{{{ */
+void API_FUNC qalloc_checkpoint(void) { /*{{{ */
   struct mapinfo_s *m = mmaps;
   struct dynmapinfo_s *dm = dynmmaps;
 

--- a/src/qloop.c
+++ b/src/qloop.c
@@ -1026,12 +1026,13 @@ static aligned_t qqloop_wrapper(void *arg_void) { /*{{{*/
   return 0;
 } /*}}}*/
 
-qqloop_handle_t *qt_loop_queue_create(qt_loop_queue_type const type,
-                                      size_t const start,
-                                      size_t const stop,
-                                      size_t const incr,
-                                      qt_loop_f const func,
-                                      void *restrict const argptr) { /*{{{*/
+qqloop_handle_t *API_FUNC
+qt_loop_queue_create(qt_loop_queue_type const type,
+                     size_t const start,
+                     size_t const stop,
+                     size_t const incr,
+                     qt_loop_f const func,
+                     void *restrict const argptr) { /*{{{*/
   qassert_ret(func, NULL);
   {
     qqloop_handle_t *restrict const h = MALLOC(sizeof(qqloop_handle_t));

--- a/src/qtimer/gethrtime.c
+++ b/src/qtimer/gethrtime.c
@@ -13,11 +13,13 @@ struct qtimer_s {
   hrtime_t stop;
 };
 
-void qtimer_start(qtimer_t q) { q->start = gethrtime(); }
+void API_FUNC qtimer_start(qtimer_t q) { q->start = gethrtime(); }
 
-unsigned long qtimer_fastrand(void) { return (unsigned long)(gethrtime()); }
+unsigned long API_FUNC qtimer_fastrand(void) {
+  return (unsigned long)(gethrtime());
+}
 
-void qtimer_stop(qtimer_t q) { q->stop = gethrtime(); }
+void API_FUNC qtimer_stop(qtimer_t q) { q->stop = gethrtime(); }
 
 double qtimer_wtime(void) { return ((double)gethrtime()) * 1e-9; }
 
@@ -30,10 +32,14 @@ double qtimer_res(void) {
 #endif
 }
 
-double qtimer_secs(qtimer_t q) { return ((double)(q->stop - q->start)) * 1e-9; }
+double API_FUNC qtimer_secs(qtimer_t q) {
+  return ((double)(q->stop - q->start)) * 1e-9;
+}
 
-qtimer_t qtimer_create() { return qt_calloc(1, sizeof(struct qtimer_s)); }
+qtimer_t API_FUNC qtimer_create() {
+  return qt_calloc(1, sizeof(struct qtimer_s));
+}
 
-void qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
+void API_FUNC qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
 
 /* vim:set expandtab: */

--- a/src/qtimer/gettime.c
+++ b/src/qtimer/gettime.c
@@ -21,7 +21,7 @@ void qtimer_start(qtimer_t q) {
   qassert(clock_gettime(CLOCK_MONOTONIC, &(q->start)), 0);
 }
 
-unsigned long qtimer_fastrand(void) {
+unsigned long API_FUNC qtimer_fastrand(void) {
   struct timespec s;
   static aligned_t volatile state = GOLDEN_RATIO;
   aligned_t volatile tmp; // this volatile is to prevent the compiler from
@@ -32,7 +32,7 @@ unsigned long qtimer_fastrand(void) {
   return tmp;
 }
 
-void qtimer_stop(qtimer_t q) {
+void API_FUNC qtimer_stop(qtimer_t q) {
   assert(q);
   qassert(clock_gettime(CLOCK_MONOTONIC, &(q->stop)), 0);
 }
@@ -50,20 +50,20 @@ double qtimer_res(void) {
   return s.tv_sec + (s.tv_nsec * 1e-9);
 }
 
-double qtimer_secs(qtimer_t q) {
+double API_FUNC qtimer_secs(qtimer_t q) {
   assert(q);
   return (q->stop.tv_sec + q->stop.tv_nsec * 1e-9) -
          (q->start.tv_sec + q->start.tv_nsec * 1e-9);
 }
 
-qtimer_t qtimer_create(void) {
+qtimer_t API_FUNC qtimer_create(void) {
   qtimer_t ret = qt_calloc(1, sizeof(struct qtimer_s));
 
   assert(ret);
   return ret;
 }
 
-void qtimer_destroy(qtimer_t q) {
+void API_FUNC qtimer_destroy(qtimer_t q) {
   assert(q);
   FREE(q, sizeof(struct qtimer_s));
 }

--- a/src/qtimer/gettimeofday.c
+++ b/src/qtimer/gettimeofday.c
@@ -14,9 +14,9 @@ struct qtimer_s {
   struct timeval start, stop;
 };
 
-void qtimer_start(qtimer_t q) { gettimeofday(&(q->start), NULL); }
+void API_FUNC qtimer_start(qtimer_t q) { gettimeofday(&(q->start), NULL); }
 
-unsigned long qtimer_fastrand(void) {
+unsigned long API_FUNC qtimer_fastrand(void) {
   struct timeval s;
 
   gettimeofday(&(s), NULL);
@@ -39,15 +39,17 @@ double qtimer_res(void) {
 #endif
 }
 
-void qtimer_stop(qtimer_t q) { gettimeofday(&(q->stop), NULL); }
+void API_FUNC qtimer_stop(qtimer_t q) { gettimeofday(&(q->stop), NULL); }
 
-double qtimer_secs(qtimer_t q) {
+double API_FUNC qtimer_secs(qtimer_t q) {
   return (q->stop.tv_sec + q->stop.tv_usec * 1e-6) -
          (q->start.tv_sec + q->start.tv_usec * 1e-6);
 }
 
-qtimer_t qtimer_create() { return qt_calloc(1, sizeof(struct qtimer_s)); }
+qtimer_t API_FUNC qtimer_create() {
+  return qt_calloc(1, sizeof(struct qtimer_s));
+}
 
-void qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
+void API_FUNC qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
 
 /* vim:set expandtab: */

--- a/src/qtimer/mach.c
+++ b/src/qtimer/mach.c
@@ -20,7 +20,7 @@ struct qtimer_s {
   uint64_t start, stop;
 };
 
-void qtimer_start(qtimer_t q) {
+void API_FUNC qtimer_start(qtimer_t q) {
   if (inited == 0) {
     if (qthread_cas(&inited, 0, 1) == 0) {
       mach_timebase_info_data_t info;
@@ -39,11 +39,11 @@ void qtimer_start(qtimer_t q) {
   q->start = mach_absolute_time();
 }
 
-unsigned long qtimer_fastrand(void) {
+unsigned long API_FUNC qtimer_fastrand(void) {
   return (unsigned long)(mach_absolute_time());
 }
 
-void qtimer_stop(qtimer_t q) { q->stop = mach_absolute_time(); }
+void API_FUNC qtimer_stop(qtimer_t q) { q->stop = mach_absolute_time(); }
 
 double qtimer_wtime(void) { return conversion * mach_absolute_time(); }
 
@@ -56,14 +56,16 @@ double qtimer_res(void) {
 #endif
 }
 
-double qtimer_secs(qtimer_t q) {
+double API_FUNC qtimer_secs(qtimer_t q) {
   uint64_t difference = q->stop - q->start;
 
   return conversion * (double)difference;
 }
 
-qtimer_t qtimer_create(void) { return qt_calloc(1, sizeof(struct qtimer_s)); }
+qtimer_t API_FUNC qtimer_create(void) {
+  return qt_calloc(1, sizeof(struct qtimer_s));
+}
 
-void qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
+void API_FUNC qtimer_destroy(qtimer_t q) { FREE(q, sizeof(struct qtimer_s)); }
 
 /* vim:set expandtab: */

--- a/src/syncvar.c
+++ b/src/syncvar.c
@@ -233,7 +233,7 @@ void INTERNAL qt_syncvar_subsystem_init(uint_fast8_t need_sync) {
   qthread_internal_cleanup_late(qt_syncvar_subsystem_shutdown);
 }
 
-int qthread_syncvar_status(syncvar_t *const v) { /*{{{ */
+int API_FUNC qthread_syncvar_status(syncvar_t *const v) { /*{{{ */
   eflags_t e = {0u, 0u, 0u, 0u, 0u};
   unsigned int realret;
 

--- a/src/syscalls/user_defined.c
+++ b/src/syscalls/user_defined.c
@@ -19,7 +19,7 @@
 
 extern TLS_DECL(qthread_t *, IO_task_struct);
 
-void qt_begin_blocking_action(void) {
+void API_FUNC qt_begin_blocking_action(void) {
   qthread_t *me;
 
   if ((qlib != NULL) && ((me = qthread_internal_self()) != NULL)) {
@@ -40,7 +40,7 @@ void qt_begin_blocking_action(void) {
   }
 }
 
-void qt_end_blocking_action(void) {
+void API_FUNC qt_end_blocking_action(void) {
   qthread_t *me = TLS_GET(IO_task_struct);
 
   if ((qlib != NULL) && (me != NULL)) {


### PR DESCRIPTION
Fixes https://github.com/sandialabs/qthreads/issues/165.

I figured I'd clear this away while setting up the new CMake build. I'm leaving the autotools one as-is since getting that configured in a compiler-independent way is more of a bother.