### PR TITLE
Realistic CMake Minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.23)
 
 set(CMAKE_C_STANDARD 11)
 


### PR DESCRIPTION
The previous value was just a placeholder. This is what the actual requirement is. It's required specifically because we use the FILE_SET argument to the `install(TARGET ...)` command to simplify the installation code. We can add compatibility with older versions later if there's some compelling reason to do so.