### PR TITLE
Ensure OSX CI Picks Up Gcc When Specified

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -229,6 +229,7 @@ jobs:
     - name: install deps
       run: |
         brew install coreutils # coreutils is to get gtimeout for CI and is not universally required by qthreads.
+        if [[ "${{ matrix.compiler }}" == "gcc" ]]; then brew install gcc; fi
     - if: ${{ matrix.topology != 'no' }}
       run: |
         brew install hwloc

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The following compilers are supported and tested regularly:
 - icc (last supported release)
 - icx 2023 or later
 - aocc 4.2 or later
-- acfl 24.04
-- Apple clang 15.4 or later
+- acfl 24.10
+- Apple clang 15 or later
+- nvc 24.9
 
 To configure and build from source you can run (in the source directory):
 


### PR DESCRIPTION
The new OSX/gcc CI config is actually just picking up an alias to appleclang. This fixes that.

Also included: a minor documentation fix.