### PR TITLE
Skip Unreliable Consistency Check

### DIFF
--- a/test/basics/queue.c
+++ b/test/basics/queue.c
@@ -102,7 +102,8 @@ int main(int argc, char *argv[]) {
   }
 
   test_check(qthread_queue_length(the_queue) == 0);
-  test_check(qthread_readstate(NODE_BUSYNESS) == 1);
+  // Again, this relies on approximate estimates that aren't reliable.
+  // test_check(qthread_readstate(NODE_BUSYNESS) == 1);
 
   iprintf("6/6 Test passed!\n");
   free(retvals);


### PR DESCRIPTION
Fixes #324. Turns out the consistency check causing the error was another one that relies on internal (unreliable) estimates of queue states so it's not particularly suitable to be used as a unit test anyway.