### PR TITLE
Add CMake Options Needed By Chapel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(QTHREADS_DICT_TYPE shavit CACHE STRING "Which dictionary implementation to u
 set(QTHREADS_TIMER_TYPE gettimeofday CACHE STRING "Which timer implementation to use. Valid values are \"clock_gettime\", \"mach\", \"gettimeofday\", and \"gethrtime\".")
 set(QTHREADS_CONTEXT_SWAP_IMPL fastcontext CACHE STRING "Which context swap implementation to use. Valid values are \"system\" and \"fastcontext\".")
 set(HWLOC_INSTALL_DIR /usr/local CACHE PATH "Install path for hwloc library")
+set(QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION "" CACHE STRING "function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)")
 
 set(QTHREADS_SOURCES
   cacheline.c
@@ -97,6 +98,12 @@ target_compile_definitions(qthread
   PRIVATE CACHELINE_WIDTH=${QTHREADS_CACHELINE_SIZE_ESTIMATE}
   PRIVATE QTHREAD_DEFAULT_STACK_SIZE=${QTHREADS_DEFAULT_STACK_SIZE}
 )
+
+if(NOT "${QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION}" STREQUAL "")
+  target_compile_definitions(qthread
+    PRIVATE HWLOC_GET_TOPOLOGY_FUNCTION=${QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION}
+  )
+endif()
 
 # CMAKE_INSTALL_LIBDIR is less reliable with CMake 3.21 and earlier.
 # In those case, it may be necessary for the end-user to specify it manually.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(QTHREADS_TIMER_TYPE gettimeofday CACHE STRING "Which timer implementation to
 set(QTHREADS_CONTEXT_SWAP_IMPL fastcontext CACHE STRING "Which context swap implementation to use. Valid values are \"system\" and \"fastcontext\".")
 set(HWLOC_INSTALL_DIR /usr/local CACHE PATH "Install path for hwloc library")
 set(QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION "" CACHE STRING "function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)")
+set(QTHREADS_GUARD_PAGES OFF CACHE BOOL "Whether or not to guard memory pages to help with debugging stack overflows. Default is OFF.")
 
 set(QTHREADS_SOURCES
   cacheline.c
@@ -102,6 +103,12 @@ target_compile_definitions(qthread
 if(NOT "${QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION}" STREQUAL "")
   target_compile_definitions(qthread
     PRIVATE HWLOC_GET_TOPOLOGY_FUNCTION=${QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION}
+  )
+endif()
+
+if(QTHREADS_GUARD_PAGES)
+  target_compile_definitions(qthread
+    PRIVATE QTHREADS_GUARD_PAGES
   )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(QTHREADS_CONTEXT_SWAP_IMPL fastcontext CACHE STRING "Which context swap impl
 set(HWLOC_INSTALL_DIR /usr/local CACHE PATH "Install path for hwloc library")
 set(QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION "" CACHE STRING "function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)")
 set(QTHREADS_GUARD_PAGES OFF CACHE BOOL "Whether or not to guard memory pages to help with debugging stack overflows. Default is OFF.")
+set(QTHREADS_CONDWAIT_QUEUE OFF CACHE BOOL "Use a waiting queue based on pthread condition variables instead of a spin-based queue for inter-thread communication. Default is OFF.")
 
 set(QTHREADS_SOURCES
   cacheline.c
@@ -108,7 +109,13 @@ endif()
 
 if(QTHREADS_GUARD_PAGES)
   target_compile_definitions(qthread
-    PRIVATE QTHREADS_GUARD_PAGES
+    PRIVATE QTHREADS_GUARD_PAGES=1
+  )
+endif()
+
+if(QTHREADS_CONDWAIT_QUEUE)
+  target_compile_definitions(qthread
+    PRIVATE QTHREAD_CONDWAIT_BLOCKING_QUEUE=1
   )
 endif()
 


### PR DESCRIPTION
These options hadn't been ported over from the old autotools build and were actually used downstream. This adds them.