### PR TITLE
Use `find_package` for Finding Hwloc in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12...3.31)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 set(CMAKE_C_STANDARD 11)
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build using shared libraries.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(CMAKE_VERSION VERSION_LESS "3.12.0")
-  cmake_minimum_required(VERSION 3.2)
-else()
-  cmake_minimum_required(VERSION 3.2...3.31)
-endif()
+cmake_minimum_required(VERSION 3.12...3.31)
 
 set(CMAKE_C_STANDARD 11)
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build using shared libraries.")

--- a/cmake/Findhwloc.cmake
+++ b/cmake/Findhwloc.cmake
@@ -1,0 +1,15 @@
+find_path(hwloc_INCLUDE_DIR hwloc.h PATH_SUFFIXES include)
+find_library(hwloc_LIBRARY
+  NAMES hwloc libhwloc
+  PATH_SUFFIXES lib lib64 lib32)
+if("${hwloc_INCLUDE_DIR}" STREQUAL "hwloc_INCLUDE_DIR-NOTFOUND" OR "${hwloc_LIBRARY}" STREQUAL "hwloc_LIBRARY-NOTFOUND")
+  set(hwloc_FOUND FALSE)
+else()
+  set(hwloc_FOUND TRUE)
+endif()
+
+if(CMAKE_VERSION VERSION_LESS "3.17.0")
+  message("-- Found hwloc: ${hwloc_FOUND}")
+else()
+  message(STATUS "Found hwloc: ${hwloc_FOUND}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,6 @@ set(QTHREADS_HASHMAP hashmap CACHE STRING "Which hashmap implementation to use. 
 set(QTHREADS_DICT_TYPE shavit CACHE STRING "Which dictionary implementation to use. Valid values are \"shavit\", \"trie\", and \"simple\".")
 set(QTHREADS_TIMER_TYPE gettimeofday CACHE STRING "Which timer implementation to use. Valid values are \"clock_gettime\", \"mach\", \"gettimeofday\", and \"gethrtime\".")
 set(QTHREADS_CONTEXT_SWAP_IMPL fastcontext CACHE STRING "Which context swap implementation to use. Valid values are \"system\" and \"fastcontext\".")
-set(HWLOC_INSTALL_DIR /usr/local CACHE PATH "Install path for hwloc library")
 set(QTHREADS_HWLOC_GET_TOPOLOGY_FUNCTION "" CACHE STRING "function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)")
 set(QTHREADS_GUARD_PAGES OFF CACHE BOOL "Whether or not to guard memory pages to help with debugging stack overflows. Default is OFF.")
 set(QTHREADS_CONDWAIT_QUEUE OFF CACHE BOOL "Use a waiting queue based on pthread condition variables instead of a spin-based queue for inter-thread communication. Default is OFF.")
@@ -79,13 +78,9 @@ target_include_directories(qthread
 set_target_properties(qthread PROPERTIES C_VISIBILITY_PRESET hidden)
 target_link_libraries(qthread PUBLIC Threads::Threads)
 if ("${QTHREADS_TOPOLOGY}" STREQUAL "hwloc" OR "${QTHREADS_TOPOLOGY}" STREQUAL "binders")
-  find_path(HWLOC_INCLUDE_DIR NAMES hwloc.h HINTS ${HWLOC_INSTALL_DIR} PATH_SUFFIXES include)
-  target_include_directories(qthread PRIVATE ${HWLOC_INCLUDE_DIR})
-  find_library(HWLOC_LIBRARY
-    NAMES hwloc libhwloc
-    HINTS ${HWLOC_INSTALL_DIR}
-    PATH_SUFFIXES lib lib64 lib32)
-  target_link_libraries(qthread PUBLIC "${HWLOC_LIBRARY}")
+  find_package(hwloc REQUIRED)
+  target_include_directories(qthread PRIVATE "${hwloc_INCLUDE_DIR}")
+  target_link_libraries(qthread PUBLIC "${hwloc_LIBRARY}")
   if ("${QTHREADS_TOPOLOGY}" STREQUAL "hwloc")
     target_compile_definitions(qthread PRIVATE USE_HWLOC_MEM_AFFINITY)
   endif()


### PR DESCRIPTION
There's a need downstream for being able to configure hwloc via the standard `_ROOT` mechanism as opposed to just supplying a hint since the hint can get unintentionally overridden by `CMAKE_MODULE_PATH`. This required setting up a find module for hwloc and then using find_package to find it instead, as is done here.