### PR TITLE
Properly Route HWLOC_GET_TOPOLOGY_FUNCTION

### DIFF
--- a/src/affinity/binders.c
+++ b/src/affinity/binders.c
@@ -87,6 +87,10 @@ static int qt_affinity_compact(int num_workers, hwloc_obj_t obj) {
 void INTERNAL qt_affinity_init(qthread_shepherd_id_t *nbshepherds,
                                qthread_worker_id_t *nbworkers,
                                size_t *hw_par) {
+#ifdef HWLOC_GET_TOPOLOGY_FUNCTION
+  extern void *HWLOC_GET_TOPOLOGY_FUNCTION;
+  topology = (hwloc_topology_t)HWLOC_GET_TOPOLOGY_FUNCTION;
+#endif
   // Note: the lack of a teardown routine will cause topology initialization
   // to be skipped if qthreads is re-initialized
   if (topology == NULL) {

--- a/src/affinity/hwloc.c
+++ b/src/affinity/hwloc.c
@@ -86,6 +86,10 @@ void INTERNAL qt_affinity_init(qthread_shepherd_id_t *nbshepherds,
                                qthread_worker_id_t *nbworkers,
                                size_t *hw_par) {
   if (qthread_cas(&initialized, 0, 1) == 0) {
+#ifdef HWLOC_GET_TOPOLOGY_FUNCTION
+    extern void *HWLOC_GET_TOPOLOGY_FUNCTION;
+    topology = (hwloc_topology_t)HWLOC_GET_TOPOLOGY_FUNCTION;
+#endif
     if (topology == NULL) {
       qassert(hwloc_topology_init(&topology), 0);
       qassert(hwloc_topology_load(topology), 0);


### PR DESCRIPTION
It wasn't getting routed through our CMake config back into the relevant places in the source files.

This bug caused a very minor performance regression in the launch downstream in chapel.