### PR TITLE
Fix Finding Qthreads Via find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 endif()
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/qthread-config.cmake.in
+++ b/qthread-config.cmake.in
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/qthread.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,8 +156,21 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT shlib
 )
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/../qthread-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/qthread-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/qthread")
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/qthread-config-version.cmake"
+  VERSION 1.22
+  COMPATIBILITY SameMajorVersion)
 install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/include/qthread
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/qthread-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/qthread-config-version.cmake"
+  DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/cmake/qthread")
+install(
+  DIRECTORY "${CMAKE_SOURCE_DIR}/include/qthread"
   DESTINATION include
   PATTERN "top" EXCLUDE
 )


### PR DESCRIPTION
CMake needs some additional config files installed to make `find_package` work correctly.