### PR TITLE
Fix buffer overflow in binders.c

### DIFF
--- a/src/affinity/binders.c
+++ b/src/affinity/binders.c
@@ -142,7 +142,7 @@ void INTERNAL qt_affinity_init(qthread_shepherd_id_t *nbshepherds,
     }
 
   } else {
-    char *bstr = qt_malloc(strlen(bindstr)+1);
+    char *bstr = qt_malloc(strlen(bindstr) + 1);
     strcpy(bstr, bindstr);
     int i, j;
     sheps.num = 1;

--- a/src/affinity/binders.c
+++ b/src/affinity/binders.c
@@ -142,7 +142,7 @@ void INTERNAL qt_affinity_init(qthread_shepherd_id_t *nbshepherds,
     }
 
   } else {
-    char *bstr = qt_malloc(strlen(bindstr));
+    char *bstr = qt_malloc(strlen(bindstr)+1);
     strcpy(bstr, bindstr);
     int i, j;
     sheps.num = 1;


### PR DESCRIPTION
Fixes a buffer overflow caused by an off-by-one error. See #365 for details

Resolves https://github.com/sandialabs/qthreads/issues/365